### PR TITLE
added core protocols that will be used when structuring backend imple…

### DIFF
--- a/iVote/Core/Protocols/PollRepository.swift
+++ b/iVote/Core/Protocols/PollRepository.swift
@@ -1,0 +1,34 @@
+//
+//  PollRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/14/25.
+//
+
+import Foundation
+
+/// A repository for managing poll data, abstracting the underlying storage mechanism (e.g., CloudKit, Firebase).
+protocol PollRepository {
+    
+    /// Fetches all available polls.
+    ///
+    /// This may include active, expired, or scheduled polls depending on implementation.
+    /// - Returns: An array of `Poll` objects.
+    /// - Throws: A repository-specific error if fetching fails.
+    func fetchPolls() async throws -> [Poll]
+    
+    /// Creates a new poll and persists it to the backend.
+        ///
+        /// The repository implementation may auto-generate the poll's `id` if not provided.
+        /// - Parameter poll: The poll to create.
+        /// - Throws: A repository-specific error if creation fails.
+    func createPoll(_ poll: Poll) async throws
+    
+    /// Fetches a single poll by its unique identifier.
+        ///
+        /// Returns `nil` if the poll does not exist.
+        /// - Parameter id: The ID of the poll.
+        /// - Returns: The matching `Poll` object or `nil`.
+        /// - Throws: A repository-specific error if lookup fails.
+    func fetchPoll(byID id: String) async throws -> Poll?
+}

--- a/iVote/Core/Protocols/UserSessionRepository.swift
+++ b/iVote/Core/Protocols/UserSessionRepository.swift
@@ -1,0 +1,26 @@
+//
+//  UserSessionRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/14/25.
+//
+
+import Foundation
+
+/// A repository for accessing and managing the current user session.
+///
+/// Abstracts user identity handling for backends like CloudKit or Firebase.
+protocol UserSessionRepository {
+
+    /// Returns the current authenticated user.
+    ///
+    /// Implementations may fetch this from iCloud, Firebase, or a local store.
+    /// - Returns: A `User` object representing the current session.
+    /// - Throws: An error if the user could not be determined or authentication failed.
+    func getCurrentUser() async throws -> User
+
+    /// Signs the user out, if supported by the backend.
+    ///
+    /// - Throws: An error if sign-out fails or is unsupported.
+    func signOut() async throws
+}

--- a/iVote/Core/Protocols/VoteRepository.swift
+++ b/iVote/Core/Protocols/VoteRepository.swift
@@ -1,0 +1,39 @@
+//
+//  VoteRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/14/25.
+//
+
+import Foundation
+
+/// A repository for submitting and retrieving votes in a poll-based system.
+///
+/// This protocol abstracts backend operations like casting a vote,
+/// tallying results, and optionally observing live changes.
+/// Designed for backend flexibility (e.g., CloudKit, Firebase).
+protocol VoteRepository {
+    
+    /// Submits a user's vote for a specific poll option.
+        ///
+        /// Backend implementations may enforce constraints such as one vote per user per poll.
+        /// - Parameter vote: The `Vote` object to submit.
+        /// - Throws: An error if the vote could not be submitted, such as a network issue or a double-vote conflict.
+    func submitVote(_ vote: Vote) async throws
+    
+    /// Retrieves a dictionary of current vote counts for a given poll.
+    ///
+    /// Keys represent `optionID`s, and values represent the number of votes received.
+    /// - Parameter pollID: The unique identifier of the poll.
+    /// - Returns: A mapping of option IDs to their current vote counts.
+    /// - Throws: An error if the counts could not be retrieved.
+    func getVoteCounts(for PollID: String) async throws -> [String: Int]
+    
+    /// Returns a stream of live votes submitted for a given poll.
+        ///
+        /// This is useful for implementing real-time vote tracking (e.g., a live lobby or results view).
+        /// The backend implementation may use CloudKit subscriptions, polling, or WebSockets.
+        /// - Parameter pollID: The ID of the poll to observe.
+        /// - Returns: An `AsyncStream` that yields `Vote` objects as they are submitted.
+    func observeVotes(for PollID: String) -> AsyncStream<Vote>
+}


### PR DESCRIPTION
closes #4 
Built out 3 protocols that will be used during backend implementation.
Added heavy DocC notes with the code for reference later on as I need to conform future pieces of code to these pro/// A repository for managing poll data, abstracting the underlying storage mechanism (e.g., CloudKit, Firebase).
protocols:

1.  PollRepository: A repository for managing poll data, abstracting the underlying storage mechanism (e.g., CloudKit, Firebase).
2. UserSessionRepository: A repository for accessing and managing the current user session. Abstracts user identity handling for backends like CloudKit or Firebase
3. VoteRepository: A repository for submitting and retrieving votes in a poll-based system. This protocol abstracts backend operations like casting a vote, tallying results, and optionally observing live changes. Designed for backend flexibility (e.g., CloudKit, Firebase).