### PR TITLE
CloudKit functionality for fetching and sending polls/votes

### DIFF
--- a/iVote/Core/AppContainer.swift
+++ b/iVote/Core/AppContainer.swift
@@ -1,0 +1,30 @@
+//
+//  AppContainer.swift
+//  iVote
+//
+//  Created by Nick on 5/15/25.
+//
+
+import Foundation
+/// A central container for dependency injection. Provides access to repositories and shared services.
+@MainActor
+final class AppContainer: ObservableObject {
+    
+    // MARK: - Repository Instances
+    
+    let pollRepository: PollRepository
+    let voteRepository: VoteRepository
+    let userSessionRepository: UserSessionRepository
+
+    // MARK: - Init
+    
+    init(
+        pollRepository: PollRepository = CloudKitPollRepository(),
+        voteRepository: VoteRepository = CloudKitVoteRepository(),
+        userSessionRepository: UserSessionRepository = CloudKitUserSessionRepository()
+    ) {
+        self.pollRepository = pollRepository
+        self.voteRepository = voteRepository
+        self.userSessionRepository = userSessionRepository
+    }
+}

--- a/iVote/Core/Models/PollRepositoryError.swift
+++ b/iVote/Core/Models/PollRepositoryError.swift
@@ -1,0 +1,16 @@
+//
+//  PollRepositoryError.swift
+//  iVote
+//
+//  Created by Nick on 5/15/25.
+//
+
+import Foundation
+
+enum PollRepositoryError: Error {
+    case invalidRecord
+}
+
+enum UserSessionError: Error {
+    case signOutNotSupported
+}

--- a/iVote/Core/Protocols/UserSessionRepository.swift
+++ b/iVote/Core/Protocols/UserSessionRepository.swift
@@ -22,5 +22,5 @@ protocol UserSessionRepository {
     /// Signs the user out, if supported by the backend.
     ///
     /// - Throws: An error if sign-out fails or is unsupported.
-    func signOut() async throws
+   // func signOut() async throws //this will not be implimented at this time because CloudKit does not support it. TODO: build extension on UserSessionRepository that supports signOut when we add support for firebase
 }

--- a/iVote/Persistence/CloudKit/CloudKitPollRepository.swift
+++ b/iVote/Persistence/CloudKit/CloudKitPollRepository.swift
@@ -1,0 +1,86 @@
+//
+//  CloudKitPollRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/15/25.
+//
+
+import Foundation
+import CloudKit
+
+/// A CloudKit-based implementation of `PollRepository` using the public iCloud database.
+final class CloudKitPollRepository: PollRepository {
+    private let database: CKDatabase = CKContainer.default().publicCloudDatabase
+    
+    // MARK: - Fetch Polls
+    
+    func fetchPolls() async throws -> [Poll] {
+        let predicate = NSPredicate(value: true) // Fetch all polls
+        let query = CKQuery(recordType: "Poll", predicate: predicate)
+        
+        let (matchedResults, _) = try await database.records(matching: query)
+        
+        return try matchedResults.compactMap { (_, result) in
+            let record = try result.get()
+            return try parsePoll(from: record)
+        }
+    }
+
+    // MARK: - Create Poll
+    
+    func createPoll(_ poll: Poll) async throws {
+        let record = CKRecord(recordType: "Poll")
+        record["question"] = poll.question
+        record["options"] = poll.options.map { $0.text } as NSArray
+        record["createdAt"] = poll.createdAt
+        if let expiresAt = poll.expiresAt {
+            record["expiresAt"] = expiresAt
+        }
+        
+        try await database.save(record)
+    }
+    
+    // MARK: - Fetch Poll by ID
+    
+    func fetchPoll(byID id: String) async throws -> Poll? {
+        let recordID = CKRecord.ID(recordName: id)
+        
+        do {
+            let record = try await database.record(for: recordID)
+            return try parsePoll(from: record)
+        } catch {
+            if (error as? CKError)?.code == .unknownItem {
+                return nil
+            } else {
+                throw error
+            }
+        }
+    }
+    
+    // MARK: - Helper
+    
+    /// Parses a `CKRecord` into a `Poll` domain model.
+    private func parsePoll(from record: CKRecord) throws -> Poll {
+        guard
+            let question = record["question"] as? String,
+            let optionsArray = record["options"] as? [String],
+            let createdAt = record["createdAt"] as? Date
+        else {
+            throw PollRepositoryError.invalidRecord
+        }
+
+        let options: [PollOption] = optionsArray.enumerated().map { index, text in
+            PollOption(id: "\(record.recordID.recordName)_\(index)", text: text)
+        }
+
+        let expiresAt = record["expiresAt"] as? Date
+
+        return Poll(
+            id: record.recordID.recordName,
+            question: question,
+            options: options,
+            createdAt: createdAt,
+            expiresAt: expiresAt
+        )
+    }
+}

--- a/iVote/Persistence/CloudKit/CloudKitUserSessionRepository.swift
+++ b/iVote/Persistence/CloudKit/CloudKitUserSessionRepository.swift
@@ -1,0 +1,29 @@
+//
+//  CloudKitUserSessionRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/15/25.
+//
+
+import CloudKit
+import Foundation
+
+/// A CloudKit-based implementation of `UserSessionRepository` that uses the iCloud account on the device.
+final class CloudKitUserSessionRepository: UserSessionRepository {
+    
+    /// The cached user ID to avoid repeated lookups
+    private var cachedUser: User?
+    
+    func getCurrentUser() async throws -> User {
+        if let cachedUser = cachedUser {
+            return cachedUser
+        }
+
+        let recordID = try await CKContainer.default().userRecordID()
+        let recordName = recordID.recordName
+
+        let user = User(id: recordName, displayName: nil)
+        cachedUser = user
+        return user
+    }
+}

--- a/iVote/Persistence/CloudKit/CloudKitVoteRepository.swift
+++ b/iVote/Persistence/CloudKit/CloudKitVoteRepository.swift
@@ -1,0 +1,74 @@
+//
+//  CloudKitVoteRepository.swift
+//  iVote
+//
+//  Created by Nick on 5/15/25.
+//
+
+import CloudKit
+import Foundation
+
+/// A CloudKit-based implementation of `VoteRepository`, using the public database.
+final class CloudKitVoteRepository: VoteRepository {
+    private let database: CKDatabase = CKContainer.default().publicCloudDatabase
+
+    // MARK: - Submit Vote
+
+    func submitVote(_ vote: Vote) async throws {
+        let record = CKRecord(recordType: "Vote")
+        record["pollID"] = vote.pollID
+        record["optionID"] = vote.optionID
+        record["userID"] = vote.userID
+        record["timestamp"] = vote.timestamp
+
+        try await database.save(record)
+    }
+
+    // MARK: - Vote Count by Poll
+
+    func getVoteCounts(for pollID: String) async throws -> [String: Int] {
+        let predicate = NSPredicate(format: "pollID == %@", pollID)
+        let query = CKQuery(recordType: "Vote", predicate: predicate)
+
+        let (matchedResults, _) = try await database.records(matching: query)
+
+        let optionVotes = try matchedResults.compactMap { (_, result) in
+            try result.get()["optionID"] as? String
+        }
+
+        return Dictionary(grouping: optionVotes, by: { $0 }).mapValues { $0.count }
+    }
+
+    // MARK: - Vote Observer
+
+    func observeVotes(for pollID: String) -> AsyncStream<Vote> {
+        AsyncStream { continuation in
+            let subscription = CKQuerySubscription(
+                recordType: "Vote",
+                predicate: NSPredicate(format: "pollID == %@", pollID),
+                subscriptionID: UUID().uuidString,
+                options: [.firesOnRecordCreation]
+            )
+
+            let notificationInfo = CKSubscription.NotificationInfo()
+            notificationInfo.shouldSendContentAvailable = true
+            subscription.notificationInfo = notificationInfo
+
+            // Add the subscription
+            Task {
+                do {
+                    try await database.save(subscription)
+                } catch {
+                    print("Subscription failed: \(error)")
+                }
+            }
+
+        //TODO: placeholder for upgrade with CloudKit push
+
+            // To stop the stream
+            continuation.onTermination = { @Sendable _ in
+                //TODO: remove subscription or cleanup
+            }
+        }
+    }
+}

--- a/iVote/iVoteApp.swift
+++ b/iVote/iVoteApp.swift
@@ -23,11 +23,13 @@ struct iVoteApp: App {
         }
     }()
     @StateObject private var appRouter = AppRouter()
+    @StateObject private var container = AppContainer()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(appRouter)
+                .environmentObject(container)
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
### Added:

- `AppContainer` to initialize and provide access to instances of `PollRepository`, `VoteRepository`, `UserSessionRepository`. This app container will be an environment var exposed to the views that need access to it.
- Error Cases for invalidRecord 
- Cloud Kit will be the first back end implemented on this project so a repository was implemented for poll, vote, and user session that conforms to the general repository protocols defined previously. 
